### PR TITLE
CoffeeScript on NPM has moved to "coffeescript (no hyphen)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/qix-/node-is-arrayish.git"
   },
   "devDependencies": {
-    "coffee-script": "^1.9.3",
+    "coffeescript": "~2.3.1",
     "coveralls": "^2.11.2",
     "istanbul": "^0.3.17",
     "mocha": "^2.2.5",


### PR DESCRIPTION
Due to some deps we get deprecation warnings about coffeescript and the hyphen in between.
Maybe we could also update to the newest coffeescript version :) 

Thanks in advance 
Oliver